### PR TITLE
Add consultant filtering and pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ npm run server
 
 Le serveur fournit des endpoints REST sous `/api/consultants` permettant de récupérer, créer, mettre à jour et supprimer des consultants.
 
+### Filtrage et pagination
+
+L'endpoint `/api/consultants` accepte plusieurs paramètres de requête :
+
+- `status` &nbsp;: filtre les consultants par statut.
+- `search` &nbsp;: recherche par prénom ou nom (insensible à la casse).
+- `limit` &nbsp;: nombre d'éléments par page.
+- `page` &nbsp;: numéro de la page (par défaut `1`).
+
+Exemple :
+
+```
+GET /api/consultants?status=available&limit=20&page=2
+```
+
 ## Démarrage de l'application
 
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@ Cette liste regroupe les étapes à réaliser pour remplacer les données simul�
    - [ ] Générer la base et créer un script de peuplement avec les données de départ.
 2. **Créer les routes API**
    - [x] Endpoints REST pour récupérer, créer, mettre à jour et supprimer chaque entité.
-   - [ ] Gestion des filtres et de la pagination pour les listes.
+   - [x] Gestion des filtres et de la pagination pour les listes.
 3. **Adapter le front‑end**
    - [x] Créer des hooks (`useClients`, `useConsultants`, …) effectuant les appels `fetch` vers l'API.
    - [x] Remplacer les `useState` contenant des mocks par ces hooks.

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,29 @@ let consultants = [
 ];
 
 app.get('/api/consultants', (req, res) => {
-  res.json(consultants);
+  let result = consultants;
+  const { status, search, limit, page = 1 } = req.query;
+
+  if (status) {
+    result = result.filter(c => c.status === status);
+  }
+
+  if (search) {
+    const s = search.toLowerCase();
+    result = result.filter(
+      c =>
+        c.firstName.toLowerCase().includes(s) ||
+        c.lastName.toLowerCase().includes(s)
+    );
+  }
+
+  if (limit) {
+    const l = parseInt(limit, 10);
+    const p = parseInt(page, 10) || 1;
+    result = result.slice((p - 1) * l, p * l);
+  }
+
+  res.json(result);
 });
 
 app.post('/api/consultants', (req, res) => {

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -7,8 +7,47 @@ const cors = require('cors');
 const app = express();
 app.use(cors());
 app.use(express.json());
-let consultants = [{ id: 1, firstName: 'Jean', lastName: 'Dupont', role: 'Dev', status: 'assigned', experience: 5 }];
-app.get('/api/consultants', (req, res) => res.json(consultants));
+
+let consultants;
+
+app.get('/api/consultants', (req, res) => {
+  let result = consultants;
+  const { status, search, limit, page = 1 } = req.query;
+
+  if (status) {
+    result = result.filter(c => c.status === status);
+  }
+
+  if (search) {
+    const s = search.toLowerCase();
+    result = result.filter(
+      c =>
+        c.firstName.toLowerCase().includes(s) ||
+        c.lastName.toLowerCase().includes(s)
+    );
+  }
+
+  if (limit) {
+    const l = parseInt(limit, 10);
+    const p = parseInt(page, 10) || 1;
+    result = result.slice((p - 1) * l, p * l);
+  }
+
+  res.json(result);
+});
+
+beforeEach(() => {
+  consultants = [
+    {
+      id: 1,
+      firstName: 'Jean',
+      lastName: 'Dupont',
+      role: 'Dev',
+      status: 'assigned',
+      experience: 5
+    }
+  ];
+});
 
 
 describe('GET /api/consultants', () => {
@@ -17,5 +56,45 @@ describe('GET /api/consultants', () => {
     expect(res.statusCode).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body[0].firstName).toBe('Jean');
+  });
+
+  it('filters by status', async () => {
+    consultants.push({
+      id: 2,
+      firstName: 'Alice',
+      lastName: 'Lemoine',
+      role: 'Dev',
+      status: 'available',
+      experience: 3
+    });
+
+    const res = await request(app)
+      .get('/api/consultants')
+      .query({ status: 'available' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].firstName).toBe('Alice');
+  });
+
+  it('supports pagination', async () => {
+    for (let i = 0; i < 10; i++) {
+      consultants.push({
+        id: i + 2,
+        firstName: `Test${i}`,
+        lastName: 'User',
+        role: 'Dev',
+        status: 'assigned',
+        experience: i
+      });
+    }
+
+    const res = await request(app)
+      .get('/api/consultants')
+      .query({ limit: 5, page: 2 });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveLength(5);
+    expect(res.body[0].firstName).toBe('Test4');
   });
 });


### PR DESCRIPTION
## Summary
- implement filtering, search and pagination for `/api/consultants`
- document the new query parameters in the README
- test the new API behaviour
- check off the corresponding item in `TODO.md`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68749e52ef7c8323a77891aa07b472b7